### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "license": "MIT",
     "require": {
         "php":">=7.0",
-        "illuminate/support":"^5.2",
-        "illuminate/cache":"^5.2",
+        "illuminate/support":"5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/cache":"5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "crcms/event":"~0.0.1"
     },
 	"autoload": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.